### PR TITLE
Update load with config and logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.2.3
+- Add `metadatalogger` and `configuration` to `load` method of `modelinterface`
+- Make `load` method of `modelinterface` a staticmethod
+- Add `log_prediction_string` method to `MetaDataLogger`, which can be used to log a string later on in the database for a given prediction run.
+
 ## Version 0.2.2
 - Bug fix in `UnitTag.get_data_filter`: The whole objects of Unit and Tag were being used in the Filter() instead of just the str version of them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## Version 0.2.3
-- Add `metadatalogger` and `configuration` to `load` method of `modelinterface`
-- Make `load` method of `modelinterface` a staticmethod
+- Add `MetaDataLogger` and `Configuration` to `load` method of `ModelInterfaceV4`
+- Make `load` method of `ModelInterfaceV4` a staticmethod
 - Add `log_prediction_string` method to `MetaDataLogger`, which can be used to log a string later on in the database for a given prediction run.
 
 ## Version 0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## Version 0.2.3
+## Version 0.2.4
 - Add `MetaDataLogger` and `Configuration` to `load` method of `ModelInterfaceV4`
 - Make `load` method of `ModelInterfaceV4` a staticmethod
 - Add `log_prediction_string` method to `MetaDataLogger`, which can be used to log a string later on in the database for a given prediction run.
+
+## Version 0.2.3
+- Add Github workflow for building the wheel
 
 ## Version 0.2.2
 - Bug fix in `UnitTag.get_data_filter`: The whole objects of Unit and Tag were being used in the Filter() instead of just the str version of them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## Version 0.2.4
+## Version 0.2.5
 - Add `MetaDataLogger` and `Configuration` to `load` method of `ModelInterfaceV4`
 - Make `load` method of `ModelInterfaceV4` a staticmethod
 - Add `log_prediction_string` method to `MetaDataLogger`, which can be used to log a string later on in the database for a given prediction run.
+
+## Version 0.2.4
+- Added LABEL to DataLabel enum
 
 ## Version 0.2.3
 - Add Github workflow for building the wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add `log_prediction_string` method to `MetaDataLogger`, which can be used to log a string later on in the database for a given prediction run.
 
 ## Version 0.2.4
-- Added LABEL to DataLabel enum
+- Added `LABEL` to `DataLabel` enum
 
 ## Version 0.2.3
 - Add Github workflow for building the wheel

--- a/twinn_ml_interface/_version.py
+++ b/twinn_ml_interface/_version.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
-__dev_version__ = "0.2.4.dev0"
+__dev_version__ = "0.2.5.dev0"

--- a/twinn_ml_interface/_version.py
+++ b/twinn_ml_interface/_version.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
-__dev_version__ = "0.2.3.dev0"
+__dev_version__ = "0.2.4.dev0"

--- a/twinn_ml_interface/interface/model_interfaces.py
+++ b/twinn_ml_interface/interface/model_interfaces.py
@@ -151,18 +151,23 @@ class ModelInterfaceV4(AnnotationProtocol):
         """
         return None
 
-    @classmethod
-    def load(cls, foldername: PathLike, filename: str) -> ModelInterfaceV4:
+    @staticmethod
+    def load(
+        foldername: PathLike, filename: str, configuration: Configuration, logger: MetaDataLogger
+    ) -> ModelInterfaceV4:
         """
         Reads the following files:
         * prefix.pkl
         * prefix.h5
         from the folder given by foldername.
-        Output is an entire instance of the fitted model that was saved
+        Output is an entire instance of the fitted model that was saved.
+        Just as with `initialize`, configuration and logger are passed for you to use.
 
         Args:
             foldername (PathLike): configurable folder name
             filename (str): name of the file
+            configuration (Configuration): an API-like object to retrieve configuration.
+            logger (MetaDataLogger): A MetaDataLogger object to write logs to MLflow later.
 
         Returns:
             Model class with everything (except data) contained within to call the

--- a/twinn_ml_interface/objectmodels/logging.py
+++ b/twinn_ml_interface/objectmodels/logging.py
@@ -141,6 +141,15 @@ class MetaDataLogger:
                     artifact_names.add(image_filename.split(".")[0])
         return artifact_names
 
+    def log_prediction_string(self, prediction_log: str):
+        """You cannot log metrics, parameters or artifacts during predictions,
+        but you can pass a string that will be logged for a given prediction run.
+
+        Args:
+            prediction_log (str): Some information to log for a prediction run.
+        """
+        self.prediction_log = prediction_log
+
     def reset_cache(self):
         """Clear all stored items in logger cache."""
         self.created_on = datetime.now(timezone.utc)


### PR DESCRIPTION
* Add `metadatalogger` and `configuration` to `load` method of `modelinterface`
* Make `load` method of `modelinterface` a staticmethod
* Add `log_prediction_string` method to `MetaDataLogger`, which can be used to log a string later on in the database for a given prediction run.