### PR TITLE
Cumulative prediction log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.2.6
+- Modified `log_prediction_string` so it can be used multiple times.
+- Removed legacy `TestModelInterfcae.test_model_accepts_kwargs`.
+
 ## Version 0.2.5
 - Add `MetaDataLogger` and `Configuration` to `load` method of `ModelInterfaceV4`
 - Make `load` method of `ModelInterfaceV4` a staticmethod

--- a/twinn_ml_interface/_version.py
+++ b/twinn_ml_interface/_version.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
-__dev_version__ = "0.2.5.dev0"
+__dev_version__ = "0.2.6.dev0"

--- a/twinn_ml_interface/interface/model_test.py
+++ b/twinn_ml_interface/interface/model_test.py
@@ -1,4 +1,3 @@
-from typing import Any
 
 
 class TestModelInterface:
@@ -26,15 +25,3 @@ class TestModelInterface:
     def test_model_inherits_base_model(self, base_model):
         if not issubclass(self.model, base_model):
             raise ValueError("model is not a subclass of base_model")
-
-    def test_model_accepts_kwargs(self, kwargs: dict[str, Any] | None = None):
-        all_kwargs = {
-            "target": "",
-            "unit_properties": {},
-            "unit_hierarchies": {},
-            "priority_tags": [],
-            "tenant_config": {},
-        }
-        if kwargs is not None:
-            all_kwargs.update(kwargs)
-        self.model(**all_kwargs)

--- a/twinn_ml_interface/interface/model_test.py
+++ b/twinn_ml_interface/interface/model_test.py
@@ -1,5 +1,3 @@
-
-
 class TestModelInterface:
     """
     Base class for testing if models follow the model interface

--- a/twinn_ml_interface/objectmodels/logging.py
+++ b/twinn_ml_interface/objectmodels/logging.py
@@ -149,7 +149,8 @@ class MetaDataLogger:
         Args:
             prediction_log (str): Some information to log for a prediction run.
         """
-        self.prediction_log += "; " + prediction_log
+        separator = "; " if self.prediction_log else ""
+        self.prediction_log += separator + prediction_log
 
     def reset_cache(self):
         """Clear all stored items in logger cache."""

--- a/twinn_ml_interface/objectmodels/logging.py
+++ b/twinn_ml_interface/objectmodels/logging.py
@@ -149,7 +149,7 @@ class MetaDataLogger:
         Args:
             prediction_log (str): Some information to log for a prediction run.
         """
-        self.prediction_log += '; ' + prediction_log
+        self.prediction_log += "; " + prediction_log
 
     def reset_cache(self):
         """Clear all stored items in logger cache."""

--- a/twinn_ml_interface/objectmodels/logging.py
+++ b/twinn_ml_interface/objectmodels/logging.py
@@ -36,6 +36,7 @@ class MetaDataLogger:
     params: dict[str, str]
     artifacts: dict[str | PathLike, str | None]
     db_logs: dict[str, Hashable]
+    prediction_log: str
 
     def __init__(self):
         self.reset_cache()
@@ -148,7 +149,7 @@ class MetaDataLogger:
         Args:
             prediction_log (str): Some information to log for a prediction run.
         """
-        self.prediction_log = prediction_log
+        self.prediction_log += '; ' + prediction_log
 
     def reset_cache(self):
         """Clear all stored items in logger cache."""
@@ -157,3 +158,4 @@ class MetaDataLogger:
         self.params = {}
         self.artifacts = {}
         self.db_logs = {}
+        self.prediction_log = ""

--- a/twinn_ml_interface/objectmodels/logging.py
+++ b/twinn_ml_interface/objectmodels/logging.py
@@ -20,7 +20,7 @@ class MetaDataLogger:
     also possible to log them to file temporarily.
 
     **Disclaimer**: Notice that `metrics`, `params`, `artifacts` and `db_logs` will only be
-    logged during for training. `prediction_log` will be logged only during prediction.
+    logged during training. `prediction_log` will be logged only during prediction.
 
     Examples
     --------

--- a/twinn_ml_interface/objectmodels/logging.py
+++ b/twinn_ml_interface/objectmodels/logging.py
@@ -19,6 +19,9 @@ class MetaDataLogger:
     stored in the object until `self.reset_cache()` is called. For larger objects it is
     also possible to log them to file temporarily.
 
+    **Disclaimer**: Notice that `metrics`, `params`, `artifacts` and `db_logs` will only be
+    logged during for training. `prediction_log` will be logged only during prediction.
+
     Examples
     --------
     >>> # Log metrics
@@ -36,7 +39,7 @@ class MetaDataLogger:
     params: dict[str, str]
     artifacts: dict[str | PathLike, str | None]
     db_logs: dict[str, Hashable]
-    prediction_log: str
+    prediction_log: list[str]
 
     def __init__(self):
         self.reset_cache()
@@ -149,8 +152,7 @@ class MetaDataLogger:
         Args:
             prediction_log (str): Some information to log for a prediction run.
         """
-        separator = "; " if self.prediction_log else ""
-        self.prediction_log += separator + prediction_log
+        self.prediction_log.append(prediction_log)
 
     def reset_cache(self):
         """Clear all stored items in logger cache."""
@@ -159,4 +161,4 @@ class MetaDataLogger:
         self.params = {}
         self.artifacts = {}
         self.db_logs = {}
-        self.prediction_log = ""
+        self.prediction_log = []


### PR DESCRIPTION
## Version 0.2.6
- Modified `log_prediction_string` so it can be used multiple times.
- Removed legacy `TestModelInterfcae.test_model_accepts_kwargs`.