### PR TITLE
Always use datalabelconfigtemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.2.7
 - Only allow returning `list[DataLabelConfigTemplate]` in interface method `get_data_config_template`.
 - In `DataLabelConfigTemplate` `unit_tag_templates` can be `list[DataLabelConfigTemplate]` or `list[UnitTag]`.
+- `DataLabelConfigTemplate.AvailabilityLevel` gets default `All`.
 
 ## Version 0.2.6
 - Modified `log_prediction_string` so it can be used multiple times.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.2.7
+- Only allow returning `list[DataLabelConfigTemplate]` in interface method `get_data_config_template`.
+- In `DataLabelConfigTemplate` `unit_tag_templates` can be `list[DataLabelConfigTemplate]` or `list[UnitTag]`.
+
 ## Version 0.2.6
 - Modified `log_prediction_string` so it can be used multiple times.
 - Removed legacy `TestModelInterfcae.test_model_accepts_kwargs`.

--- a/twinn_ml_interface/_version.py
+++ b/twinn_ml_interface/_version.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
-__dev_version__ = "0.2.6.dev0"
+__dev_version__ = "0.2.7.dev0"

--- a/twinn_ml_interface/interface/model_interfaces.py
+++ b/twinn_ml_interface/interface/model_interfaces.py
@@ -42,12 +42,12 @@ class ModelInterfaceV4(AnnotationProtocol):
         ...
 
     @staticmethod
-    def get_data_config_template() -> list[DataLabelConfigTemplate] | list[UnitTag]:
+    def get_data_config_template() -> list[DataLabelConfigTemplate]:
         """The specification of data needed to train and predict with the model.
 
         Result:
-            list[DataLabelConfigTemplate] | list[UnitTag]: The data needed to train and
-                predict with the model, either as template or as list of literals.
+            list[DataLabelConfigTemplate]: The data needed to train and
+                predict with the model.
         """
         ...
 

--- a/twinn_ml_interface/objectmodels/hierarchy.py
+++ b/twinn_ml_interface/objectmodels/hierarchy.py
@@ -166,8 +166,8 @@ class LabelConfig:
 @dataclass
 class DataLabelConfigTemplate:
     data_level: DataLevel
-    unit_tag_templates: list[UnitTagTemplate]
-    availability_level: AvailabilityLevel
+    unit_tag_templates: list[UnitTagTemplate] | list[UnitTag]
+    availability_level: AvailabilityLevel = AvailabilityLevel.ALL
     desired_tag_number: int | None = None
     label_config: LabelConfig | None = None
     max_lookback: timedelta | None = None


### PR DESCRIPTION
- Only allow returning `list[DataLabelConfigTemplate]` in interface method `get_data_config_template`.
- In `DataLabelConfigTemplate` `unit_tag_templates` can be `list[DataLabelConfigTemplate]` or `list[UnitTag]`.