### PR TITLE
add modelled unit to Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.2.8
+- Add property `Configuration.modelled_unit_code`, that can be used when the target of the model is not the same as the modelled unit.
+
 ## Version 0.2.7
 - Only allow returning `list[DataLabelConfigTemplate]` in interface method `get_data_config_template`.
 - In `DataLabelConfigTemplate` `unit_tag_templates` can be `list[DataLabelConfigTemplate]` or `list[UnitTag]`.

--- a/twinn_ml_interface/_version.py
+++ b/twinn_ml_interface/_version.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.7"
+__version__ = "0.2.8"
 
-__dev_version__ = "0.2.7.dev0"
+__dev_version__ = "0.2.8.dev0"

--- a/twinn_ml_interface/objectmodels/configuration.py
+++ b/twinn_ml_interface/objectmodels/configuration.py
@@ -1,9 +1,10 @@
 from functools import cached_property
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 from .hierarchy import RelativeType, Unit, UnitTag, UnitTagTemplate
 
 
+@runtime_checkable
 class Configuration(Protocol):
     @cached_property
     def target_name(self) -> str:
@@ -13,7 +14,13 @@ class Configuration(Protocol):
         ...
 
     @property
+    def modelled_unit_code(self) -> str:
+        """Get the unit that is being modelled."""
+        ...
+
+    @property
     def tenant(self) -> dict[str, Any]:
+        """Get tenant object from database."""
         ...
 
     @cached_property


### PR DESCRIPTION
 Add property `Configuration.modelled_unit_code`, that can be used when the target of the model is not the same as the modelled unit.