### PR TITLE
transform removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.4.0
+- Removed `transform` function from `DataLabelConfigTemplate` and replaced by `horizon` parameter, that can be used to request future data (useful for `ModelCategory.PREDICTION`)
+
 ## Version 0.3.2
 - Fix hash from `UnitTag`.
 

--- a/twinn_ml_interface/_version.py
+++ b/twinn_ml_interface/_version.py
@@ -1,3 +1,3 @@
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
-__dev_version__ = "0.3.2.dev0"
+__dev_version__ = "0.4.0.dev0"

--- a/twinn_ml_interface/objectmodels/hierarchy.py
+++ b/twinn_ml_interface/objectmodels/hierarchy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum, IntEnum, auto
-from typing import Any, Callable
+from typing import Any
 
 
 # Whether the model outputs anomalies, predictions or actuals.
@@ -146,11 +146,7 @@ class DataLabelConfigTemplate:
     desired_tag_number: int | None = None
     label_config: LabelConfig | None = None
     max_lookback: timedelta | None = None
-
-    def f(*args, **kwargs):
-        return args[0]
-
-    transform: Callable = f
+    horizon: timedelta | None = None
 
 
 @dataclass


### PR DESCRIPTION
Removed `transform` function from `DataLabelConfigTemplate` and replaced by `horizon` parameter, that can be used to request future data (useful for `ModelCategory.PREDICTION`)